### PR TITLE
書記素クラスタ単位でカウントする

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "next": "14.1.4",
         "react": "^18",
-        "react-dom": "^18"
+        "react-dom": "^18",
+        "split-graphemes": "^0.5.0"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -4173,6 +4174,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/split-graphemes": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/split-graphemes/-/split-graphemes-0.5.0.tgz",
+      "integrity": "sha512-TTZ4IPmxuGZOPqhKLHscOeVf568gDP8JE8FxaZU/k30Q3Ra1BRhMv8d9jq1R6A/6T8wSz6ozYn3aJ5skgP6omA=="
     },
     "node_modules/streamsearch": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -9,20 +9,20 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "next": "14.1.4",
     "react": "^18",
     "react-dom": "^18",
+    "next": "14.1.4",
     "split-graphemes": "^0.5.0"
   },
   "devDependencies": {
+    "typescript": "^5",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "autoprefixer": "^10.0.1",
-    "eslint": "^8",
-    "eslint-config-next": "14.1.4",
     "postcss": "^8",
     "tailwindcss": "^3.3.0",
-    "typescript": "^5"
+    "eslint": "^8",
+    "eslint-config-next": "14.1.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,19 +9,20 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "next": "14.1.4",
     "react": "^18",
     "react-dom": "^18",
-    "next": "14.1.4"
+    "split-graphemes": "^0.5.0"
   },
   "devDependencies": {
-    "typescript": "^5",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "autoprefixer": "^10.0.1",
+    "eslint": "^8",
+    "eslint-config-next": "14.1.4",
     "postcss": "^8",
     "tailwindcss": "^3.3.0",
-    "eslint": "^8",
-    "eslint-config-next": "14.1.4"
+    "typescript": "^5"
   }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { SetStateAction, useState } from "react";
+import { splitGraphemes } from "split-graphemes";
 
 export default function Home() {
   const [text, setText] = useState("");
@@ -68,7 +69,9 @@ export default function Home() {
           placeholder="テキストを入力してください..."
           className="w-full min-h-[120px] p-3 mb-4 text-gray-800 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-200"
         />
-        <p className="text-lg text-gray-600">文字数: {text.length}</p>
+        <p className="text-lg text-gray-600">
+          文字数: {splitGraphemes(text).length}
+        </p>
         <button
           onClick={copyToClipboard}
           className="absolute bottom-4 right-4 px-4 py-2 text-white bg-blue-500 rounded-lg hover:bg-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-200"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { SetStateAction, useState } from "react";
+// @ts-expect-error 型定義が存在しない
 import { splitGraphemes } from "split-graphemes";
 
 export default function Home() {


### PR DESCRIPTION
一部の絵文字が含まれていると、文字数が見た目より多くカウントされるようです
https://gyazo.com/da9ecc52d3e9b4f0d3a600f7a12dc35d

[書記素クラスタ](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/Segmenter#grapheme)単位で文字数をカウントすれば、見た目どおりの文字数をカウントできそうです

[Intl.Segmenter](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter)を使えば、ライブラリなしで文字列を書記素クラスタに分割できます
しかしIntl.Segmenterは一部のブラウザ（Safari 14.1以前、Firefox）が未対応なため、
[split-graphemes](https://www.npmjs.com/package/split-graphemes)ライブラリを使ってみました

## 動作確認したこと

`絵文字👨‍👩‍👦‍👦`が4文字としてカウントされるようになったこと
[![Image from Gyazo](https://i.gyazo.com/6970ff758c23b5dad3c12d64979d3554.png)](https://gyazo.com/6970ff758c23b5dad3c12d64979d3554)

改行もカウントされなくなります